### PR TITLE
max_parallel_workers_per_gather up to 4 workers

### DIFF
--- a/webpack/selectors/configuration.js
+++ b/webpack/selectors/configuration.js
@@ -244,7 +244,7 @@ export const parallelSettings = createSelector(
     if (dbVersion >= 9.6) {
       config.push({
         key: 'max_parallel_workers_per_gather',
-        value: Math.ceil(cpuNum / 2)
+        value: Math.min(Math.ceil(cpuNum / 2), 4)
       })
     }
 


### PR DESCRIPTION
parallelizing with more than 4 workers doesn't seems highly accurate