### PR TITLE
add psql 13 and make it the default

### DIFF
--- a/webpack/reducers/configuration/constants.js
+++ b/webpack/reducers/configuration/constants.js
@@ -1,6 +1,6 @@
 // postgresql versions
-export const DEFAULT_DB_VERSION = 12
-export const DB_VERSIONS = [DEFAULT_DB_VERSION, 11, 10, 9.6, 9.5, 9.4, 9.3, 9.2]
+export const DEFAULT_DB_VERSION = 13
+export const DB_VERSIONS = [DEFAULT_DB_VERSION, 12, 11, 10, 9.6, 9.5, 9.4, 9.3, 9.2]
 // os types
 export const OS_LINUX = 'linux'
 export const OS_WINDOWS = 'windows'

--- a/webpack/selectors/configuration.js
+++ b/webpack/selectors/configuration.js
@@ -63,6 +63,11 @@ const getDbDefaultValues = createSelector(
         ['max_worker_processes']: 8,
         ['max_parallel_workers_per_gather']: 2,
         ['max_parallel_workers']: 8
+      },
+      13: {
+        ['max_worker_processes']: 8,
+        ['max_parallel_workers_per_gather']: 2,
+        ['max_parallel_workers']: 8
       }
     }[dbVersion]
   )


### PR DESCRIPTION
Hey, thanks for your awesome tool!

since PostgreSQL13 came out recently, I added it and made it the new default. There weren't any changes to the default values in [`postgresql.conf`](https://github.com/postgres/postgres/blob/REL_13_STABLE/src/backend/utils/misc/postgresql.conf.sample) as far as I can see, so I kept the values which are the default since version 10.