### PR TITLE
Fix up English

### DIFF
--- a/webpack/pages/about/index.js
+++ b/webpack/pages/about/index.js
@@ -7,7 +7,7 @@ const AboutPage = () => (
   <div className="about-page">
     <img className="about-page-logo" src={Logo} alt="PGTune" />
     <p>
-      <strong>PGTune</strong> calculate configuration for PostgreSQL based on the maximum performance for a given hardware configuration. It isn't a <a href="https://en.wikipedia.org/wiki/No_Silver_Bullet">silver bullet</a> for the optimization settings of PostgreSQL. Many settings depend not only on the hardware configuration, but also on the size of the database, the number of clients and the complexity of queries, so that optimally configure the database can only be given all these parameters.
+      <strong>PGTune</strong> calculate configuration for PostgreSQL based on the maximum performance for a given hardware configuration. It isn't a <a href="https://en.wikipedia.org/wiki/No_Silver_Bullet">silver bullet</a> for the optimization settings of PostgreSQL. Many settings depend not only on the hardware configuration, but also on the size of the database, the number of clients and the complexity of queries. An optimal configuration of the database can only be made given all these parameters are taken into account.
     </p>
     <h3>Useful links</h3>
     <ul className="about-page-list">


### PR DESCRIPTION
"optimally configure the database can only be given all these parameters" doesn't make sense grammatically.