### PR TITLE
Recommend minimal wal_level on desktop environments

### DIFF
--- a/src/common/components/configurationView/index.jsx
+++ b/src/common/components/configurationView/index.jsx
@@ -30,7 +30,8 @@ import {
   selectEffectiveIoConcurrency,
   selectParallelSettings,
   selectWorkMem,
-  selectWarningInfoMessages
+  selectWarningInfoMessages,
+  selectWalLevel
 } from '@features/configuration/configurationSlice'
 import {
   openConfigTab,
@@ -110,6 +111,7 @@ const ConfigurationView = () => {
   const effectiveCacheSizeVal = useSelector(selectEffectiveCacheSize)
   const maintenanceWorkMemVal = useSelector(selectMaintenanceWorkMem)
   const checkpointSegmentsVal = useSelector(selectCheckpointSegments)
+  const walLevelVal = useSelector(selectWalLevel)
   const checkpointCompletionTargetVal = useSelector(selectCheckpointCompletionTarget)
   const walBuffersVal = useSelector(selectWalBuffers)
   const defaultStatisticsTargetVal = useSelector(selectDefaultStatisticsTarget)
@@ -153,6 +155,8 @@ const ConfigurationView = () => {
       return [item.key, formatValue(item.value)]
     })
 
+  const getWalLevel = () => walLevelVal.map((item) => [item.key, item.value])
+
   const getParallelSettings = () => parallelSettingsVal.map((item) => [item.key, item.value])
 
   const postgresqlConfig = () => {
@@ -171,6 +175,7 @@ const ConfigurationView = () => {
     ]
       .concat(getCheckpointSegments())
       .concat(getParallelSettings())
+      .concat(getWalLevel())
 
     return configData
       .filter((item) => !!item[1])

--- a/src/features/configuration/__tests__/configurationSlice.test.js
+++ b/src/features/configuration/__tests__/configurationSlice.test.js
@@ -4,7 +4,8 @@ import {
   selectDefaultStatisticsTarget,
   selectRandomPageCost,
   selectEffectiveIoConcurrency,
-  selectParallelSettings
+  selectParallelSettings,
+  selectWalLevel
 } from '../configurationSlice'
 
 describe('selectIsConfigured', () => {
@@ -266,5 +267,30 @@ describe('selectParallelSettings', () => {
       { key: 'max_parallel_workers', value: 31 },
       { key: 'max_parallel_maintenance_workers', value: 4 }
     ])
+  })
+})
+
+describe('selectWalLevel', () => {
+  it('desktop app', () => {
+    expect(
+      selectWalLevel({
+        configuration: {
+          dbType: 'desktop'
+        }
+      })
+    ).toEqual([
+      { key: 'wal_level', value: 'minimal' },
+      { key: 'max_wal_senders', value: '0' }
+    ])
+  })
+
+  it('web app', () => {
+    expect(
+      selectWalLevel({
+        configuration: {
+          dbType: 'web'
+        }
+      })
+    ).toEqual([])
   })
 })

--- a/src/features/configuration/configurationSlice.js
+++ b/src/features/configuration/configurationSlice.js
@@ -388,5 +388,23 @@ export const selectWarningInfoMessages = createSelector(
   }
 )
 
+export const selectWalLevel = createSelector([selectDBType], (dbType) => {
+  if (dbType === DB_TYPE_DESKTOP) {
+    return [
+      {
+        key: 'wal_level',
+        value: 'minimal'
+      },
+      // max_wal_senders must be 0 when wal_level=minimal
+      {
+        key: 'max_wal_senders',
+        value: '0'
+      }
+    ]
+  }
+
+  return []
+})
+
 // Export the slice reducer as the default export
 export default configurationSlice.reducer


### PR DESCRIPTION
`wal_level` config documentation: https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-WAL-LEVEL

My assumption here is that the desktop application environment does not include data replication and generally meant for development.

Inspired by https://www.youtube.com/watch?v=YDv18olF1ew&list=WL&index=37&t=395s